### PR TITLE
Add zlib as subproject to avoid dynamic dependency

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,7 @@ chump_lib_sources = [
 # Fetch the dependency
 nlohmann_json_dep = subproject('nlohmann_json').get_variable('nlohmann_json_dep')
 openssl_dep = subproject('openssl', default_options: ['prefer_static=true'], required: true).get_variable('openssl_dep')
+zlib_dep = subproject('zlib', default_options: ['prefer_static=true'], required: true).get_variable('zlib_dep')
 libcurl_dep = subproject('curl', default_options: ['prefer_static=true'], required: true).get_variable('curl_dep')
 minizip_dep = subproject('minizip-ng', required: true).get_variable('minizip_ng_dep')
 
@@ -20,10 +21,10 @@ chump_lib = static_library(
   'chump_lib',
   sources: chump_lib_sources,
   include_directories : inc,
-  dependencies : [nlohmann_json_dep, libcurl_dep, openssl_dep, minizip_dep, cheaders_dep],
+  dependencies : [nlohmann_json_dep, libcurl_dep, openssl_dep, minizip_dep, cheaders_dep, zlib_dep],
 )
 
 chump_lib_dep = declare_dependency(
-  dependencies: [nlohmann_json_dep, libcurl_dep, openssl_dep, minizip_dep, cheaders_dep],
+  dependencies: [nlohmann_json_dep, libcurl_dep, openssl_dep, minizip_dep, cheaders_dep, zlib_dep],
   include_directories : inc,
   link_with : chump_lib)

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = zlib-1.3.1
+source_url = http://zlib.net/fossils/zlib-1.3.1.tar.gz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zlib_1.3.1-1/zlib-1.3.1.tar.gz
+source_filename = zlib-1.3.1.tar.gz
+source_hash = 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+patch_filename = zlib_1.3.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.3.1-1/get_patch
+patch_hash = e79b98eb24a75392009cec6f99ca5cdca9881ff20bfa174e8b8926d5c7a47095
+wrapdb_version = 1.3.1-1
+
+[provide]
+zlib = zlib_dep


### PR DESCRIPTION
In issue #20 the build on ubuntu was failing because the meson build was trying to dynamically link with `zlib`, but it wasn't able to. Add a `zlib` subproject to address this.